### PR TITLE
For generating also the StickData [generatebond=true]

### DIFF
--- a/HIVE/ModuleSystem/moduledata/Loader/LoadPDB/pdbloader.lua
+++ b/HIVE/ModuleSystem/moduledata/Loader/LoadPDB/pdbloader.lua
@@ -10,7 +10,7 @@ end
 
 function LoadPDB:Do()
     self:UpdateValue()
-    return self.loader:Load(self.value.filepath)
+    return self.loader:Load(self.value.filepath,'true')
 end
 
 function LoadPDB:BallData()


### PR DESCRIPTION
The "LoadPDB" Node has the "StickData" output. However, the default condition for StickData generation ("generatebound" variable) is "false".  
